### PR TITLE
Unable to fetch libpq-dev: work around

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,8 @@ RUN /usr/local/bin/pip3 install git+git://github.com/jupyter/dockerspawner.git
 RUN /usr/local/bin/pip3 install git+git://github.com/ryanlovett/jh-google-oauthenticator.git
 
 # Install psycopg2
+RUN apt-get update
+RUN apt-get -y install libssl-dev
 RUN apt-get -y install libpq-dev
 RUN /usr/local/bin/pip3 install psycopg2
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,6 @@ RUN /usr/local/bin/pip3 install git+git://github.com/ryanlovett/jh-google-oauthe
 
 # Install psycopg2
 RUN apt-get update
-RUN apt-get -y install libssl-dev
 RUN apt-get -y install libpq-dev
 RUN /usr/local/bin/pip3 install psycopg2
 


### PR DESCRIPTION
Encountered the following error when building image from source:

E: Failed to fetch http://archive.ubuntu.com/ubuntu/pool/main/p/postgresql-9.3/libpq5_9.3.9-0ubuntu0.14.04_amd64.deb  404  Not Found [IP: 91.189.91.14 80]
E: Failed to fetch http://archive.ubuntu.com/ubuntu/pool/main/p/postgresql-9.3/libpq-dev_9.3.9-0ubuntu0.14.04_amd64.deb  404  Not Found [IP: 91.189.91.14 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?

Added the following to Dockerfile as a work around fix:

```
Install psycopg2
RUN apt-get update
RUN apt-get -y install libssl-dev
RUN apt-get -y install libpq-dev
RUN /usr/local/bin/pip3 install psycopg2
```
