### PR TITLE
hosts are now 6 lines apart (not 5)

### DIFF
--- a/swarmspawner.py
+++ b/swarmspawner.py
@@ -30,7 +30,7 @@ class SwarmSpawner(SystemUserSpawner):
         # look up mapping of node names to ip addresses
         info = yield self.docker('info')
         num_nodes = int(info['DriverStatus'][3][1])
-        node_info = info['DriverStatus'][4::5]
+        node_info = info['DriverStatus'][4::6]
         self.node_info = {}
         for i in range(num_nodes):
             node, ip_port = node_info[i]


### PR DESCRIPTION
Looks like the docker API has changed slightly - host information is now separated by 6 lines:
eg.

```
In [10]: import docker
In [11]: cli = docker.Client(base_url='tcp://127.0.0.1:3376')
In [12]: info = cli.info()
In [13]: info['DriverStatus'][4::6]
Out[13]: [['myhost1', '111.222.333.3:2375'], ['myhost2', '111.222.333.6:2375']]
```
